### PR TITLE
Add Initial Leaderboard Display With Filtering And Mock Data

### DIFF
--- a/frontend/src/pages/leaderboard.css
+++ b/frontend/src/pages/leaderboard.css
@@ -1,9 +1,146 @@
-.main-box {
-  min-height: 100vh;
+.page {
+  flex: 1;
   width: 100vw;
   background: white;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 32px 0;
+}
+
+.container {
+  width: 100%;
+  max-width: 1000px;
+}
+
+.card {
+  padding: 40px;
+  border-radius: 24px;
+  margin-bottom: 32px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+  background: white;
+}
+
+.section-title {
+  font-weight: 700;
+  color: #00796b;
+  margin-bottom: 24px;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.controls label {
+  font-weight: 600;
+  color: #424242;
+}
+
+.country-select {
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: white;
+  font-size: 14px;
+  color: #424242;
+}
+
+.country-select:focus {
+  outline: none;
+  border-color: #0288d1;
+  box-shadow: 0 0 0 2px rgba(2, 136, 209, 0.2);
+}
+
+.status {
+  padding: 24px;
+  text-align: center;
+  border-radius: 12px;
+  margin: 16px 0;
+  font-weight: 500;
+}
+
+.status.loading {
+  background: #f5f5f5;
+  color: #666;
+}
+
+.status.error {
+  background: #ffebee;
+  color: #c62828;
+}
+
+.status.empty {
+  background: #f3e5f5;
+  color: #7b1fa2;
+}
+
+.table-container {
+  overflow-x: auto;
+  margin: 16px 0;
+}
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.leaderboard-table th {
+  background: #f8f9fa;
+  padding: 12px 16px;
+  text-align: left;
+  font-weight: 600;
+  color: #424242;
+  border-bottom: 2px solid #e0e0e0;
+  position: sticky;
+  top: 0;
+}
+
+.leaderboard-table th:first-child {
+  text-align: center;
+  width: 60px;
+}
+
+.leaderboard-table th:nth-child(3),
+.leaderboard-table th:nth-child(4),
+.leaderboard-table th:nth-child(5) {
+  text-align: right;
+}
+
+.leaderboard-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e0e0;
+  color: #424242;
+}
+
+.leaderboard-table td:first-child {
+  text-align: center;
+  font-weight: 600;
+  color: #0288d1;
+}
+
+.leaderboard-table td:nth-child(3),
+.leaderboard-table td:nth-child(4),
+.leaderboard-table td:nth-child(5) {
+  text-align: right;
+  font-weight: 500;
+}
+
+.leaderboard-table tbody tr:hover {
+  background: #f8f9fa;
+}
+
+
+.updated-at {
+  text-align: center;
+  font-size: 12px;
+  color: #666;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #e0e0e0;
 }

--- a/frontend/src/pages/leaderboard.tsx
+++ b/frontend/src/pages/leaderboard.tsx
@@ -1,8 +1,245 @@
+import { useState, useEffect } from 'react';
 import './leaderboard.css';
 
-export default function Leaderboard() {
+type LeaderboardRow = {
+  regionId: string;
+  name: string;
+  totalAmountCents: number;
+  donationCount: number;
+  highestSingleDonationCents: number;
+};
+
+type LeaderboardResponse = {
+  country?: string;
+  regions: LeaderboardRow[];
+  updatedAt: string;
+};
+
+const mockDataByCountry: Record<string, LeaderboardResponse> = {
+  "HK": {
+    country: "HK",
+    regions: [
+      {
+        regionId: "hk-central",
+        name: "Central Hong Kong",
+        totalAmountCents: 2500000,
+        donationCount: 45,
+        highestSingleDonationCents: 100000
+      },
+      {
+        regionId: "hk-wan-chai",
+        name: "Wan Chai",
+        totalAmountCents: 1800000,
+        donationCount: 32,
+        highestSingleDonationCents: 75000
+      },
+      {
+        regionId: "hk-tsim-sha-tsui",
+        name: "Tsim Sha Tsui",
+        totalAmountCents: 1200000,
+        donationCount: 28,
+        highestSingleDonationCents: 50000
+      }
+    ],
+    updatedAt: new Date().toISOString()
+  },
+  "SG": {
+    country: "SG",
+    regions: [
+      {
+        regionId: "sg-marina-bay",
+        name: "Marina Bay",
+        totalAmountCents: 1900000,
+        donationCount: 38,
+        highestSingleDonationCents: 85000
+      },
+      {
+        regionId: "sg-orchard",
+        name: "Orchard",
+        totalAmountCents: 1400000,
+        donationCount: 29,
+        highestSingleDonationCents: 60000
+      },
+      {
+        regionId: "sg-sentosa",
+        name: "Sentosa",
+        totalAmountCents: 900000,
+        donationCount: 22,
+        highestSingleDonationCents: 45000
+      }
+    ],
+    updatedAt: new Date().toISOString()
+  },
+  "MY": {
+    country: "MY",
+    regions: [
+      {
+        regionId: "my-kl-city",
+        name: "Kuala Lumpur City",
+        totalAmountCents: 1600000,
+        donationCount: 35,
+        highestSingleDonationCents: 70000
+      },
+      {
+        regionId: "my-petaling-jaya",
+        name: "Petaling Jaya",
+        totalAmountCents: 1100000,
+        donationCount: 26,
+        highestSingleDonationCents: 55000
+      },
+      {
+        regionId: "my-johor-bahru",
+        name: "Johor Bahru",
+        totalAmountCents: 800000,
+        donationCount: 20,
+        highestSingleDonationCents: 40000
+      }
+    ],
+    updatedAt: new Date().toISOString()
+  }
+};
+
+const getAllCountriesData = (): LeaderboardResponse => {
+  const allRegions = Object.values(mockDataByCountry).flatMap(data => data.regions);
+  return {
+    regions: allRegions,
+    updatedAt: new Date().toISOString()
+  };
+};
+
+async function fetchLeaderboard(country: string): Promise<LeaderboardResponse> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL;
+  
+  if (!baseUrl) {
+    return country === "ALL" ? getAllCountriesData() : mockDataByCountry[country] || mockDataByCountry["HK"];
+  }
+
+  try {
+    const url = country === "ALL" 
+      ? `${baseUrl}/leaderboard`
+      : `${baseUrl}/leaderboard?country=${country}`;
+    
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    
+    return await response.json();
+  } catch (error) {
+    console.warn('API request failed, using mock data:', error);
+    return country === "ALL" ? getAllCountriesData() : mockDataByCountry[country] || mockDataByCountry["HK"];
+  }
+}
+
+export default function LeaderboardPage() {
+  const [country, setCountry] = useState<string>("HK");
+  const [data, setData] = useState<LeaderboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const hkd = new Intl.NumberFormat('en-HK', { style: 'currency', currency: 'HKD' });
+
+  useEffect(() => {
+    async function loadData() {
+      setLoading(true);
+      setError(null);
+      
+      try {
+        const result = await fetchLeaderboard(country);
+        setData(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load data');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadData();
+  }, [country]);
+
+  const handleCountryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setCountry(e.target.value);
+  };
+
+  const sortedRegions = data?.regions.slice().sort((a, b) => b.totalAmountCents - a.totalAmountCents) || [];
+
   return (
-    <div className="main-box">
+    <div className="page">
+      <div className="container">
+        <div style={{ textAlign: "center", marginBottom: "32px" }}>
+          <h1 className="section-title">
+            Donation Leaderboard
+          </h1>
+        </div>
+        
+        <div className="card">
+          <div className="controls">
+            <label htmlFor="country-select">Filter by Country:</label>
+            <select
+              id="country-select"
+              value={country}
+              onChange={handleCountryChange}
+              className="country-select"
+            >
+              <option value="ALL">All Countries</option>
+              <option value="HK">Hong Kong</option>
+              <option value="SG">Singapore</option>
+              <option value="MY">Malaysia</option>
+            </select>
+          </div>
+
+          {loading && (
+            <div className="status loading">
+              Loading leaderboard data...
+            </div>
+          )}
+
+          {error && (
+            <div className="status error">
+              Error: {error}
+            </div>
+          )}
+
+          {!loading && !error && sortedRegions.length === 0 && (
+            <div className="status empty">
+              No data available for the selected country.
+            </div>
+          )}
+
+          {!loading && !error && sortedRegions.length > 0 && (
+            <div className="table-container">
+              <table className="leaderboard-table">
+                <thead>
+                  <tr>
+                    <th>Rank</th>
+                    <th>Region</th>
+                    <th>Total Raised (HKD)</th>
+                    <th>Donations</th>
+                    <th>Highest Donation (HKD)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedRegions.map((region, index) => (
+                    <tr key={region.regionId}>
+                      <td>{index + 1}</td>
+                      <td>{region.name}</td>
+                      <td>{hkd.format(region.totalAmountCents / 100)}</td>
+                      <td>{region.donationCount}</td>
+                      <td>{hkd.format(region.highestSingleDonationCents / 100)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {data && (
+            <div className="updated-at">
+              Last updated: {new Date(data.updatedAt).toLocaleString()}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
  • Implement complete leaderboard page with country filter dropdown (ALL, HK, SG, MY)
  • Add responsive table displaying rank, region, total raised, donation count, and highest donation
  • Include loading, error, and empty states with proper user feedback
  • Format currency values using HKD formatter for consistent display (Can be changed currently standardized all to HKD)

Mock Data is just to test and observe the functionality of the leaderboard. 

<img width="824" height="413" alt="image" src="https://github.com/user-attachments/assets/f924a671-4335-475e-a9d2-cc48be1941a9" />
